### PR TITLE
Ensure coverage artifact names are unique per run

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,6 +1,9 @@
 # Pytest, pylint, codecov and publish. That's is folks
 name: Build and publish
 
+env:
+  COVERAGE_ARTIFACT_NAME: coverage-${{ github.run_id }}
+
 on:
   push:
     branches: [master]
@@ -34,7 +37,7 @@ jobs:
       - name: Upload code coverage to be accessed in next job
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: ${{ env.COVERAGE_ARTIFACT_NAME }}
           path: ./coverage.xml
 
   # TIP FOR FUTURE: canonical layout! checkout, unpack is strictly necessary in steps section!111
@@ -45,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage
+          name: ${{ env.COVERAGE_ARTIFACT_NAME }}
       - uses: codecov/codecov-action@v4
         name: Upload coverage to Codecov
         with:


### PR DESCRIPTION
### **User description**
## Summary
- define a workflow-level coverage artifact name using `github.run_id` to guarantee unique uploads
- reuse the shared artifact name when downloading coverage prior to Codecov upload

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca09051608832594f4a5c13afb6535


___

### **PR Type**
Other


___

### **Description**
- Define unique coverage artifact names using `github.run_id`

- Update upload and download steps to use shared artifact name

- Prevent artifact naming conflicts in concurrent workflow runs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Environment"] --> B["Coverage Artifact Name"]
  B --> C["Upload Coverage"]
  B --> D["Download Coverage"]
  C --> E["Codecov Upload"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.yml</strong><dd><code>Add unique coverage artifact naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/default.yml

<ul><li>Add workflow-level environment variable for unique coverage artifact <br>naming<br> <li> Update upload-artifact step to use dynamic artifact name<br> <li> Update download-artifact step to use same dynamic name<br> <li> Ensure artifact uniqueness across concurrent workflow runs</ul>


</details>


  </td>
  <td><a href="https://github.com/xfenix/envcast/pull/6/files#diff-54411c2dc70cdd657fcf8a7bdebeff500fbb1245570abb83c22b3f62db03e71b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

