### PR TITLE
Ensure workflow artifacts use unique names

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -2,7 +2,7 @@
 name: Build and publish
 
 env:
-  COVERAGE_ARTIFACT_NAME: coverage-${{ github.run_id }}
+  COVERAGE_ARTIFACT_BASE_NAME: coverage-${{ github.run_id }}
 
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
       - name: Upload code coverage to be accessed in next job
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.COVERAGE_ARTIFACT_NAME }}
+          name: ${{ env.COVERAGE_ARTIFACT_BASE_NAME }}-${{ matrix.python-version }}
           path: ./coverage.xml
 
   # TIP FOR FUTURE: canonical layout! checkout, unpack is strictly necessary in steps section!111
@@ -48,7 +48,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ env.COVERAGE_ARTIFACT_NAME }}
+          pattern: ${{ env.COVERAGE_ARTIFACT_BASE_NAME }}-*
+          merge-multiple: true
       - uses: codecov/codecov-action@v4
         name: Upload coverage to Codecov
         with:


### PR DESCRIPTION
### **User description**
## Summary
- ensure coverage artifacts uploaded from the test matrix receive unique names
- adjust the download step to retrieve all coverage artifacts safely

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ca0b4eb9a48325a71699ebf5f7d0b8


___

### **PR Type**
Enhancement


___

### **Description**
- Fix artifact name conflicts in test matrix workflow

- Add unique Python version suffix to coverage artifacts

- Update download step to merge multiple coverage files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Matrix"] --> B["Upload Coverage Artifacts"]
  B --> C["coverage-runid-python3.8"]
  B --> D["coverage-runid-python3.9"]
  B --> E["coverage-runid-python3.10"]
  C --> F["Download with Pattern"]
  D --> F
  E --> F
  F --> G["Merge Multiple Artifacts"]
  G --> H["Upload to Codecov"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.yml</strong><dd><code>Fix artifact naming conflicts in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/default.yml

<ul><li>Rename environment variable from <code>COVERAGE_ARTIFACT_NAME</code> to <br><code>COVERAGE_ARTIFACT_BASE_NAME</code><br> <li> Add Python version suffix to artifact names in upload step<br> <li> Update download step to use pattern matching with <code>merge-multiple: true</code></ul>


</details>


  </td>
  <td><a href="https://github.com/xfenix/envcast/pull/7/files#diff-54411c2dc70cdd657fcf8a7bdebeff500fbb1245570abb83c22b3f62db03e71b">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

